### PR TITLE
Pass output folder to App for saving trees

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -85,7 +85,9 @@ def start_program(id, file_path, chm_path, file_column_mapping, chm_column_mappi
     root.withdraw() # Hide the startup menu.
     # Create your App instance using the new window.
     from app import App
-    app = App(main_window, MyData, MyCHM, MyPlotCenters,startup_root=root)
+    app = App(main_window, MyData, MyCHM, MyPlotCenters, startup_root=root)
+    # Pass the output folder to the App so it writes Trees there.
+    app.output_folder = output_folder
     
 
 


### PR DESCRIPTION
## Summary
- Forward the configured output directory to `App` so tree data writes to the chosen folder.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ada27c1e788329a54366f5d9b41294