### PR TITLE
refactor: remove unused import

### DIFF
--- a/ficp.py
+++ b/ficp.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy.spatial.distance import cdist
-from scipy.optimize import minimize_scalar
 
 class FractionalICP:
     def __init__(self, source, target, lambda_val=3.0, threshold=1e-6, max_iterations=1000):


### PR DESCRIPTION
## Summary
- remove unused minimize_scalar import from FractionalICP implementation

## Testing
- `python -m py_compile ficp.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada27764f883298c96c60a8affefb7