### PR TITLE
Add optional tree height handling and tests

### DIFF
--- a/tests/test_tree_height.py
+++ b/tests/test_tree_height.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from trees import Stand
+
+
+def build_stand(tmp_path):
+    data = [
+        {
+            'Stand': 1,
+            'PLOT': 1,
+            'TreeID': 't1',
+            'X_GROUND': 0.0,
+            'Y_GROUND': 0.0,
+            'STEMDIAM': 30.0,
+            'H': 15.0,
+        },
+        {
+            'Stand': 1,
+            'PLOT': 1,
+            'TreeID': 't2',
+            'X_GROUND': 1.0,
+            'Y_GROUND': 1.0,
+            'STEMDIAM': 'bad',  # missing diameter -> should be derived from height
+            'H': 20.0,
+        },
+        {
+            'Stand': 1,
+            'PLOT': 1,
+            'TreeID': 't3',
+            'X_GROUND': 2.0,
+            'Y_GROUND': 2.0,
+            'STEMDIAM': 30.0,
+            'H': 'bad',  # missing height -> should be derived from diameter
+        },
+    ]
+    df = pd.DataFrame(data)
+    csv_path = tmp_path / 'trees.csv'
+    df.to_csv(csv_path, index=False)
+    mapping = {
+        'StandID': 'Stand',
+        'PlotID': 'PLOT',
+        'TreeID': 'TreeID',
+        'X': 'X_GROUND',
+        'Y': 'Y_GROUND',
+        'DBH': 'STEMDIAM',
+        'H': 'H',
+    }
+    return Stand(1, csv_path, mapping=mapping, sep=',')
+
+
+def test_height_parsing_and_derivation(tmp_path):
+    stand = build_stand(tmp_path)
+    plot = stand.plots[0]
+    t1, t2, t3 = plot.trees
+
+    # Row with both height and diameter
+    assert t1.stemdiam == pytest.approx(0.30)
+    assert t1.height == pytest.approx(15.0)
+
+    # Diameter missing -> derived from height
+    expected_diam = t2.get_diameter(20.0)
+    assert t2.stemdiam == pytest.approx(expected_diam)
+    assert t2.height == pytest.approx(20.0)
+
+    # Height missing -> derived from diameter
+    expected_height = t3.get_height(0.30)
+    assert t3.stemdiam == pytest.approx(0.30)
+    assert t3.height == pytest.approx(expected_height)

--- a/trees.py
+++ b/trees.py
@@ -281,6 +281,7 @@ class Stand:
             x_col = mapping.get('X', 'X_GROUND')
             y_col = mapping.get('Y', 'Y_GROUND')
             dbh_col = mapping.get('DBH', 'STEMDIAM')
+            h_col   = mapping.get('H', 'H')
             species_col = mapping.get('Species', 'Species')
             xc_col = mapping.get('XC', x_col)
             yc_col = mapping.get('YC', y_col)
@@ -292,6 +293,7 @@ class Stand:
             x_col = 'X_GROUND'
             y_col = 'Y_GROUND'
             dbh_col = 'STEMDIAM'
+            h_col = 'H'
             species_col = 'Species'
             xc_col = 'XC'
             yc_col = 'YC'
@@ -315,9 +317,21 @@ class Stand:
                 stemdiam_cm = float(row.get(dbh_col, 0))
             except (ValueError, TypeError):
                 stemdiam_cm = None
+            # Optional height (assumed meters) -> Tree expects decimeters
+            try:
+                height_m = float(row.get(h_col)) if h_col in row else None
+            except (ValueError, TypeError):
+                height_m = None
+            height_dm = height_m * 10 if height_m is not None else None
 
-            tree = Tree(tree_id, x=row.get(x_col), y=row.get(y_col),
-                        species=row.get(species_col), stemdiam_cm=stemdiam_cm)
+            tree = Tree(
+                tree_id,
+                x=row.get(x_col),
+                y=row.get(y_col),
+                species=row.get(species_col),
+                stemdiam_cm=stemdiam_cm,
+                height_dm=height_dm,
+            )
             # Check if the plot already exists; if not, create it.
             plot = next((p for p in self.plots if p.plotid == plot_id), None)
             if not plot:


### PR DESCRIPTION
## Summary
- allow `Stand` to read an optional height column and pass the value to `Tree`
- convert provided heights from meters to decimeters before tree instantiation
- add tests verifying height parsing and height/diameter derivation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb27ed5a88329b4ed5debcc19e28e