### PR TITLE
feat: wire Näslund parameters and keymap refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Co-Registration Game helps forest managers and researchers to:
 - **Visualize** tree and CHM data in a unified viewport.
 - **Adjust** tree plot positions interactively using rotation, translation, and flipping.
 - **Optimize** the registration between field-measured tree data and remotely sensed CHM data.
-- **Impute** missing tree parameters (e.g., height or diameter) using a Näslund (1936) height-diameter relationship.
+- **Impute** missing tree parameters (e.g., height or diameter) using a Näslund (1936) height–diameter relationship (Startup parameters are applied during data load when one variable is missing).
 
 The tool integrates a Tkinter-based startup menu for data selection and configuration with a Pygame-based interactive display for the co-registration process.
 
@@ -93,8 +93,8 @@ The startup menu (built with Tkinter) will allow you to:
 - Select the Tree Data File and CHM Data File.
 - Specify CSV separators.
 - Map your CSV column names to the required fields (StandID, PlotID, TreeID, X, Y, DBH, H).
-- Choose whether to impute missing values for DBH or Height using the provided Näslund height-diameter relationship (only one imputation option per file is allowed).
-- Set Näslund model parameters (with a real-time preview of the height curve).
+- Choose whether to impute missing values for DBH or Height using the provided Näslund height–diameter relationship (only one imputation option per file is allowed).
+- Set Näslund model parameters (with a real-time preview of the height curve). These parameters are applied to imputation during data loading when one of DBH/Height is missing.
 - Select an output folder for the transformed tree data. Transformation logs are stored in `./Transformations`.
 
 Once configured, click `Start` to launch the interactive application.
@@ -219,6 +219,8 @@ Period (`.`): Mark the current plot as unplaceable (do not save its position).
 
 `Space`: Toggle flash mode (visualize different data layers).
 Double-tap to enter end-result view.
+
+`H`: Toggle in-app help overlay with key bindings.
 
 ## Outputs
 The program generates the following outputs:

--- a/render.py
+++ b/render.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pygame
+from scipy.spatial.distance import cdist
+from typing import Tuple
+
+
+def to_screen_coordinates(geo_coord, stand_center, scale_factor, screen_size) -> Tuple[int, int]:
+    """World (x,y) -> screen (px,px)."""
+    screen_x = (geo_coord[0] - stand_center[0]) * scale_factor + screen_size[0] / 2
+    screen_y = (geo_coord[1] - stand_center[1]) * scale_factor + screen_size[1] / 2
+    return int(screen_x), int(screen_y)
+
+
+def get_viewport_scale(stand, screen_size) -> float:
+    """Compute a scale so all trees fit within the window with a margin."""
+    all_trees = [tree for plot in stand.plots for tree in plot.trees]
+    if not all_trees:
+        return 1.0
+    coords = np.array([(tree.currentx, tree.currenty) for tree in all_trees])
+    furthest_distance = max(np.sqrt((x - stand.center[0]) ** 2 + (y - stand.center[1]) ** 2) for x, y in coords)
+    max_screen_distance = min(screen_size) / 2 - 20  # padding
+    scale_factor = max_screen_distance / (furthest_distance + 2)
+    return scale_factor
+
+
+class PlotCenters:
+    """Utility for drawing/holding plot centers near the stand center."""
+
+    def __init__(self, stand):
+        centers = np.array([plot.current_center for plot in stand.plots if plot.current_center is not None])
+        self.centers = centers[cdist(centers, np.array([stand.center])).squeeze() < 70] if centers.size else np.array([])
+
+    def draw_single_center(self, screen, center, color, alpha, stand_center, scale_factor, screen_size):
+        pos = to_screen_coordinates(center, stand_center, scale_factor, screen_size)
+        r = 2
+        alpha_surface = pygame.Surface((r * 2, r * 2), pygame.SRCALPHA)
+        alpha_surface.fill((0, 0, 0, 0))
+        pygame.draw.circle(alpha_surface, color + (int(255 * alpha),), (r, r), r)
+        screen.blit(alpha_surface, (pos[0] - r, pos[1] - r))
+
+    def draw_centers(self, screen, color, alpha, stand_center, scale_factor, screen_size):
+        for center in self.centers:
+            self.draw_single_center(screen, center, color, alpha, stand_center, scale_factor, screen_size)
+
+
+def draw_tree(screen, tree, tree_scale, color, alpha, stand_center, scale_factor, screen_size, tree_component=False):
+    pos = to_screen_coordinates((tree.currentx, tree.currenty), stand_center, scale_factor, screen_size)
+    if tree_component:
+        radius = max(int(tree.stemdiam * 10 * scale_factor / 2), 1) * tree_scale
+    else:
+        radius = max(int(tree.height / 10 * scale_factor / 2), 1) * tree_scale
+    alpha_surface = pygame.Surface((radius * 2, radius * 2), pygame.SRCALPHA)
+    alpha_surface.fill((0, 0, 0, 0))
+    pygame.draw.circle(alpha_surface, color + (int(255 * alpha),), (radius, radius), radius)
+    screen.blit(alpha_surface, (pos[0] - radius, pos[1] - radius))
+
+
+def draw_plot(screen, tree_scale, plot, alpha, stand_center, scale_factor, screen_size, tree_component=False, fill_color=(0, 0, 255)):
+    for tree in plot.trees:
+        draw_tree(screen, tree, tree_scale, fill_color, alpha, stand_center, scale_factor, screen_size, tree_component)
+
+
+def draw_chm(stems, screen, tree_scale, alpha, stand_center, scale_factor, screen_size, tree_component=False):
+    for tree in stems:
+        draw_tree(screen, tree, tree_scale, (107, 107, 107), alpha, stand_center, scale_factor, screen_size, tree_component)
+
+
+def draw_arrow(screen, arrow_position, target_position, color=(0, 0, 0)):
+    dx = target_position[0] - arrow_position[0]
+    dy = target_position[1] - arrow_position[1]
+    angle = np.arctan2(dy, dx)
+    length = 50
+    endx = arrow_position[0] + length * np.cos(angle)
+    endy = arrow_position[1] + length * np.sin(angle)
+    pygame.draw.line(screen, color, arrow_position, (endx, endy), 3)
+    arrowhead_length = 10
+    arrow_angle = np.pi / 6
+    leftx = endx + arrowhead_length * np.cos(angle + np.pi - arrow_angle)
+    lefty = endy + arrowhead_length * np.sin(angle + np.pi - arrow_angle)
+    rightx = endx + arrowhead_length * np.cos(angle + np.pi + arrow_angle)
+    righty = endy + arrowhead_length * np.sin(angle + np.pi + arrow_angle)
+    pygame.draw.polygon(screen, color, [(endx, endy), (leftx, lefty), (rightx, righty)])
+
+
+def draw_polygon(screen, points, color=(0, 255, 0)):
+    if len(points) > 1:
+        pygame.draw.lines(screen, color, False, points, 3)
+    for point in points:
+        pygame.draw.circle(screen, color, point, 5)
+
+
+def is_point_in_polygon(point, polygon):
+    x, y = point
+    n = len(polygon)
+    if n < 3:
+        return False
+    inside = False
+    p1x, p1y = polygon[0]
+    for i in range(n + 1):
+        p2x, p2y = polygon[i % n]
+        if y > min(p1y, p2y):
+            if y <= max(p1y, p2y):
+                if x <= max(p1x, p2x):
+                    if p1y != p2y:
+                        xinters = (y - p1y) * (p2x - p1x) / (p2y - p1y) + p1x
+                    if p1x == p2x or x <= xinters:
+                        inside = not inside
+        p1x, p1y = p2x, p2y
+    return inside

--- a/startup.py
+++ b/startup.py
@@ -8,13 +8,8 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import logging
 # Import the new modular components:
 from trees import Stand, SavedStand
-from chm_plot import (
-    CHMPlot,
-    SavedPlot,
-    PlotCenters,
-    Naslund1936kwargs,
-    plot_height_curve,
-)
+from chm_plot import CHMPlot, SavedPlot, plot_height_curve
+from render import PlotCenters
 # Note: the main application is launched from app.App
 
 def update_column_options(file_path, sep, comboboxes, mapping_vars):
@@ -68,10 +63,29 @@ def start_program(id, file_path, chm_path, file_column_mapping, chm_column_mappi
     if not os.path.isdir(output_folder):
         os.makedirs(output_folder, exist_ok=True)
 
-    # Pass the mapping and separator to the Stand initializer.
-    MyData = Stand(ID=id, file_path=file_path, mapping=file_column_mapping, sep=file_sep)
-    # Optionally, update CHMPlot similarly if needed:
-    MyCHM = CHMPlot(file_path=chm_path, x=MyData.center[0], y=MyData.center[1], dist=70, mapping=chm_column_mapping,sep=chm_sep)
+    # Prepare Näslund parameters for imputation when toggles are enabled.
+    naslund_params = tuple(params) if params else None
+    # Pass the mapping, separator, toggles, and params to the loaders.
+    MyData = Stand(
+        ID=id,
+        file_path=file_path,
+        mapping=file_column_mapping,
+        sep=file_sep,
+        impute_dbh=file_calculate_dbh,
+        impute_h=file_calculate_h,
+        naslund_params=naslund_params if (file_calculate_dbh or file_calculate_h) else None,
+    )
+    MyCHM = CHMPlot(
+        file_path=chm_path,
+        x=MyData.center[0],
+        y=MyData.center[1],
+        dist=70,
+        mapping=chm_column_mapping,
+        sep=chm_sep,
+        impute_dbh=chm_calculate_dbh,
+        impute_h=chm_calculate_h,
+        naslund_params=naslund_params if (chm_calculate_dbh or chm_calculate_h) else None,
+    )
 
     MyPlotCenters = PlotCenters(MyData)
     


### PR DESCRIPTION
## Summary
- pass startup-specified Näslund parameters into loaders and trees for on-load imputation
- extract rendering utilities into a dedicated module and centralize key bindings with a generated help overlay
- document that imputation parameters are applied during data loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adbc8a253483299adb4d9ce7fc8df2