### PR TITLE
Fix SCALED flag loss on window resize

### DIFF
--- a/app.py
+++ b/app.py
@@ -334,7 +334,9 @@ class App:
                     self.on_closing()
                 elif event.type == pygame.VIDEORESIZE:
                     self.screen_size = event.size
-                    self.screen = pygame.display.set_mode(self.screen_size, pygame.RESIZABLE)
+                    self.screen = pygame.display.set_mode(
+                        self.screen_size, pygame.SCALED | pygame.RESIZABLE
+                    )
                     self.scale_factor = get_viewport_scale(self.plot_stand, self.screen_size)
                 # Prefer modern Pygame 2 window focus events when available
                 elif hasattr(pygame, "WINDOWEVENT") and event.type == pygame.WINDOWEVENT:


### PR DESCRIPTION
## Summary
- Preserve `pygame.SCALED` flag when handling `VIDEORESIZE` events to maintain consistent visual scaling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc2d9f96883299adc843c233a1217