### PR TITLE
Skip incomplete CHM rows lacking height and DBH

### DIFF
--- a/chm_plot.py
+++ b/chm_plot.py
@@ -153,6 +153,12 @@ class CHMPlot(Plot):
             if height is not None and height > 450:
                 continue
 
+            if missing_height and (
+                stemdiam_value is None or
+                (isinstance(stemdiam_value, float) and np.isnan(stemdiam_value))
+            ):
+                continue  # skip rows with neither H nor DBH
+
             tree = Tree(
                 tree_id=row[idals_col],
                 x=row[x_col],

--- a/tests/test_chm_plot.py
+++ b/tests/test_chm_plot.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from chm_plot import CHMPlot
+
+
+def test_skip_rows_without_height_or_dbh(tmp_path):
+    data = [
+        {'X': 0.0, 'Y': 0.0, 'IDALS': 't1', 'DBH': 30.0},
+        {'X': 1.0, 'Y': 1.0, 'IDALS': 't2', 'DBH': ''},
+    ]
+    df = pd.DataFrame(data)
+    csv_path = tmp_path / 'chm.csv'
+    df.to_csv(csv_path, index=False)
+
+    plot = CHMPlot(csv_path, sep=',')
+
+    assert len(plot.trees) == 1
+    assert plot.trees[0].tree_id == 't1'


### PR DESCRIPTION
## Summary
- avoid creating trees with neither height nor DBH in `CHMPlot`
- test that CHM rows missing both values are ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adc2ee0384832989af8a631f1dc8cd