### PR TITLE
Flatten transformation data for CSV export

### DIFF
--- a/app.py
+++ b/app.py
@@ -800,31 +800,43 @@ class App:
     def store_transformations(self, plot, fail=False):
         """Store per-plot transformation details for later CSV export."""
         if not plot.trees:
-            # If the plot is empty, store NA values.
+            # If the plot is empty, store NA values for all primitives.
             self.plot_transformations[plot.plotid] = {
-                "original_center": plot.center,
+                "original_center": tuple(map(float, plot.center)),
                 "final_center": pd.NA,
-                "translation": pd.NA,
+                "tx": pd.NA,
+                "ty": pd.NA,
+                "r00": pd.NA,
+                "r01": pd.NA,
+                "r10": pd.NA,
+                "r11": pd.NA,
                 "flip": pd.NA,
-                "rotation": pd.NA
             }
             return
         R, t, flip = plot.get_transform()
         if not fail:
             self.plot_transformations[plot.plotid] = {
-                "original_center": plot.center,
-                "final_center": plot.current_center,
-                "translation": t,
-                "flip": flip,
-                "rotation": R
+                "original_center": tuple(map(float, plot.center)),
+                "final_center": tuple(map(float, plot.current_center)),
+                "tx": float(t[0]),
+                "ty": float(t[1]),
+                "r00": float(R[0, 0]),
+                "r01": float(R[0, 1]),
+                "r10": float(R[1, 0]),
+                "r11": float(R[1, 1]),
+                "flip": bool(flip),
             }
         else:
             self.plot_transformations[plot.plotid] = {
-                "original_center": plot.center,
+                "original_center": tuple(map(float, plot.center)),
                 "final_center": pd.NA,
-                "translation": pd.NA,
+                "tx": pd.NA,
+                "ty": pd.NA,
+                "r00": pd.NA,
+                "r01": pd.NA,
+                "r10": pd.NA,
+                "r11": pd.NA,
                 "flip": pd.NA,
-                "rotation": pd.NA
             }
 
 

--- a/tests/test_transformation_serialization.py
+++ b/tests/test_transformation_serialization.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import numpy as np
+import sys
+from pathlib import Path
+import types
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for pynput to avoid GUI dependencies during import
+mock_pynput = types.ModuleType("pynput")
+mock_keyboard = types.ModuleType("keyboard")
+mock_pynput.keyboard = mock_keyboard
+sys.modules.setdefault("pynput", mock_pynput)
+sys.modules.setdefault("pynput.keyboard", mock_keyboard)
+
+from trees import Plot, Tree
+from app import App
+
+
+def test_transformation_serialization_primitives(tmp_path):
+    plot = Plot(plotid=1)
+    plot.append_tree(Tree(1, 0.0, 0.0, stemdiam_cm=1.0, height_dm=10.0))
+    plot.append_tree(Tree(2, 1.0, 0.0, stemdiam_cm=1.0, height_dm=10.0))
+    plot.append_tree(Tree(3, 0.0, 1.0, stemdiam_cm=1.0, height_dm=10.0))
+
+    app = App.__new__(App)
+    app.plot_transformations = {}
+    app.store_transformations(plot)
+
+    df = pd.DataFrame.from_dict(app.plot_transformations, orient="index")
+    csv_path = tmp_path / "transforms.csv"
+    df.to_csv(csv_path, index=False)
+    df_loaded = pd.read_csv(csv_path)
+
+    # Ensure primitive columns exist and contain numeric data
+    for col in ["tx", "ty", "r00", "r01", "r10", "r11"]:
+        assert col in df_loaded.columns
+        assert np.issubdtype(df_loaded[col].dtype, np.number)
+
+    # Identity rotation and zero translation for unmodified plot
+    assert np.isclose(df_loaded.loc[0, "tx"], 0.0)
+    assert np.isclose(df_loaded.loc[0, "ty"], 0.0)
+    assert np.isclose(df_loaded.loc[0, "r00"], 1.0)
+    assert np.isclose(df_loaded.loc[0, "r01"], 0.0)
+    assert np.isclose(df_loaded.loc[0, "r10"], 0.0)
+    assert np.isclose(df_loaded.loc[0, "r11"], 1.0)


### PR DESCRIPTION
## Summary
- Store plot transformations using primitive fields (`tx`, `ty`, `r00`, `r01`, `r10`, `r11`, `flip`) instead of NumPy arrays
- Added regression test verifying transformation CSV columns are numeric primitives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc3008edc832981e128302a879b4d