### PR TITLE
Handle missing DBH values while loading Stand data

### DIFF
--- a/trees.py
+++ b/trees.py
@@ -335,8 +335,9 @@ class Stand:
         for row in reader:
             plot_id = row.get(plot_col)
             tree_id = row.get(tree_col)
+            raw_dbh = row.get(dbh_col) if dbh_col in row else None
             try:
-                stemdiam_cm = float(row.get(dbh_col, 0))
+                stemdiam_cm = float(raw_dbh) if raw_dbh not in (None, "") else None
             except (ValueError, TypeError):
                 stemdiam_cm = None
             # Optional height (meters) -> decimeters for Tree


### PR DESCRIPTION
## Summary
- Avoid defaulting missing DBH values to 0 when reading Stand data
- Convert empty or missing DBH entries to `None`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcaf721648329bd065bc57caa5377