### PR TITLE
Skip incomplete tree rows

### DIFF
--- a/chm_plot.py
+++ b/chm_plot.py
@@ -153,11 +153,15 @@ class CHMPlot(Plot):
             if height is not None and height > 450:
                 continue
 
-            if missing_height and (
-                stemdiam_value is None or
-                (isinstance(stemdiam_value, float) and np.isnan(stemdiam_value))
+            # Skip rows that provide neither metric
+            if (
+                (height is None or (isinstance(height, float) and np.isnan(height)))
+                and (
+                    stemdiam_value is None
+                    or (isinstance(stemdiam_value, float) and np.isnan(stemdiam_value))
+                )
             ):
-                continue  # skip rows with neither H nor DBH
+                continue
 
             tree = Tree(
                 tree_id=row[idals_col],


### PR DESCRIPTION
## Summary
- skip CHM rows that lack both height and DBH information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adcafdb78c83299851d8be2899f2d5