### PR TITLE
Add height and DBH imputation helpers for trees

### DIFF
--- a/tests/test_tree_impute.py
+++ b/tests/test_tree_impute.py
@@ -1,0 +1,19 @@
+import pytest
+
+from trees import Tree
+
+
+def test_impute_height_with_diameter_only():
+    t = Tree('t1', 0.0, 0.0)
+    t.stemdiam = 0.30
+    t.impute_height()
+    expected_height = t.get_height(0.30)
+    assert t.height == pytest.approx(expected_height)
+
+
+def test_impute_dbh_with_height_only():
+    t = Tree('t2', 0.0, 0.0)
+    t.height = 20.0
+    t.impute_dbh()
+    expected_diam = t.get_diameter(20.0)
+    assert t.stemdiam == pytest.approx(expected_diam)

--- a/trees.py
+++ b/trees.py
@@ -71,6 +71,28 @@ class Tree:
 
         return min(find_diameter(height, *params), 1.5)
 
+    def impute_height(self) -> None:
+        """Impute height using the stored diameter if missing.
+
+        If the tree's ``height`` attribute is ``None`` but ``stemdiam`` is
+        available, this method estimates the missing height using the
+        :func:`get_height` Näslund (1936) model.
+        """
+
+        if getattr(self, "height", None) is None and getattr(self, "stemdiam", None) is not None:
+            self.height = self.get_height(self.stemdiam)
+
+    def impute_dbh(self) -> None:
+        """Impute diameter using the stored height if missing.
+
+        When ``stemdiam`` is ``None`` but ``height`` is provided, this method
+        back-computes DBH by inverting the Näslund model via
+        :func:`get_diameter`.
+        """
+
+        if getattr(self, "stemdiam", None) is None and getattr(self, "height", None) is not None:
+            self.stemdiam = self.get_diameter(self.height)
+
 
 class PlotIterator:
     def __init__(self, plot):


### PR DESCRIPTION
## Summary
- add `impute_height`/`impute_dbh` methods to compute missing values via Näslund equation
- test imputation when only height or DBH provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb033358832980062c8fb410635d