### PR TITLE
Add explicit Näslund-based tree metric imputation

### DIFF
--- a/chm_plot.py
+++ b/chm_plot.py
@@ -165,8 +165,12 @@ class CHMPlot(Plot):
                 y=row[y_col],
                 stemdiam_cm=stemdiam_value,
                 height_dm=height,
-                naslund_params=self.naslund_params,
+                naslund_params=self.naslund_params if (self.impute_dbh or self.impute_h) else None,
             )
+            if self.impute_h:
+                tree.impute_height(self.naslund_params)
+            if self.impute_dbh:
+                tree.impute_dbh(self.naslund_params)
             self.append_tree(tree)
 
         pts = np.array([[tree.x, tree.y] for tree in self.trees])

--- a/tests/test_tree_height.py
+++ b/tests/test_tree_height.py
@@ -50,7 +50,7 @@ def build_stand(tmp_path):
         'DBH': 'STEMDIAM',
         'H': 'H',
     }
-    return Stand(1, csv_path, mapping=mapping, sep=',')
+    return Stand(1, csv_path, mapping=mapping, sep=',', impute_dbh=True, impute_h=True)
 
 
 def test_height_parsing_and_derivation(tmp_path):


### PR DESCRIPTION
## Summary
- Add `Tree.impute_height` and `Tree.impute_dbh` helpers and defer imputation until explicitly invoked
- Update `Stand` and `CHMPlot` to trigger imputation only when corresponding flags are enabled
- Adjust tests to opt in to DBH/height imputation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adcb0b1ad08329917e2fd3eeca1d3c