### PR TITLE
Add optional Näslund-based imputation for CHM data

### DIFF
--- a/chm_plot.py
+++ b/chm_plot.py
@@ -165,8 +165,14 @@ class CHMPlot(Plot):
                 y=row[y_col],
                 stemdiam_cm=stemdiam_value,
                 height_dm=height,
-                naslund_params=self.naslund_params,
+                naslund_params=self.naslund_params
+                if (self.impute_dbh or self.impute_h)
+                else None,
             )
+            if self.impute_h:
+                tree.impute_height(self.naslund_params)
+            if self.impute_dbh:
+                tree.impute_dbh(self.naslund_params)
             self.append_tree(tree)
 
         pts = np.array([[tree.x, tree.y] for tree in self.trees])


### PR DESCRIPTION
## Summary
- add `impute_height` and `impute_dbh` methods to Tree for explicit Näslund-based estimation
- gate DBH/height imputation in CHMPlot and Stand behind optional flags
- update height/diameter helpers to accept custom parameter sets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb0fc29c8329bcf223f81bda323d