### PR TITLE
Remove automatic tree metric imputation

### DIFF
--- a/chm_plot.py
+++ b/chm_plot.py
@@ -147,7 +147,7 @@ class CHMPlot(Plot):
                     stemdiam_value = float(row[dbh_col]) if (dbh_col in row and row[dbh_col] not in [None, ""]) else None
                 except Exception as e:
                     stemdiam_value = None
-                height = None  # Let the Tree class impute height.
+                height = None  # Height will be imputed later if requested.
 
             # Optionally skip trees with unrealistic heights.
             if height is not None and height > 450:
@@ -167,6 +167,10 @@ class CHMPlot(Plot):
                 height_dm=height,
                 naslund_params=self.naslund_params,
             )
+            if self.impute_h and tree.height is None and tree.stemdiam is not None:
+                tree.height = tree.get_height(tree.stemdiam)
+            if self.impute_dbh and tree.stemdiam is None and tree.height is not None:
+                tree.stemdiam = tree.get_diameter(tree.height)
             self.append_tree(tree)
 
         pts = np.array([[tree.x, tree.y] for tree in self.trees])

--- a/tests/test_tree_height.py
+++ b/tests/test_tree_height.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from trees import Stand
+from trees import Stand, Tree
+from chm_plot import CHMPlot
 
 
-def build_stand(tmp_path):
+def build_stand(tmp_path, impute_dbh=True, impute_h=True):
     data = [
         {
             'Stand': 1,
@@ -50,7 +51,32 @@ def build_stand(tmp_path):
         'DBH': 'STEMDIAM',
         'H': 'H',
     }
-    return Stand(1, csv_path, mapping=mapping, sep=',')
+    return Stand(1, csv_path, mapping=mapping, sep=',', impute_dbh=impute_dbh, impute_h=impute_h)
+
+
+def build_chm_files(tmp_path):
+    height_df = pd.DataFrame([
+        {
+            'IDALS': 'c1',
+            'X': 0.0,
+            'Y': 0.0,
+            'H': 15.0,
+        }
+    ])
+    h_path = tmp_path / 'chm_h.csv'
+    height_df.to_csv(h_path, index=False)
+
+    dbh_df = pd.DataFrame([
+        {
+            'IDALS': 'c2',
+            'X': 1.0,
+            'Y': 1.0,
+            'DBH': 30.0,
+        }
+    ])
+    d_path = tmp_path / 'chm_d.csv'
+    dbh_df.to_csv(d_path, index=False)
+    return h_path, d_path
 
 
 def test_height_parsing_and_derivation(tmp_path):
@@ -71,3 +97,47 @@ def test_height_parsing_and_derivation(tmp_path):
     expected_height = t3.get_height(0.30)
     assert t3.stemdiam == pytest.approx(0.30)
     assert t3.height == pytest.approx(expected_height)
+
+
+def test_stand_no_impute(tmp_path):
+    stand = build_stand(tmp_path, impute_dbh=False, impute_h=False)
+    plot = stand.plots[0]
+    t1, t2, t3 = plot.trees
+
+    assert t1.stemdiam == pytest.approx(0.30)
+    assert t1.height == pytest.approx(15.0)
+    assert t2.stemdiam is None
+    assert t2.height == pytest.approx(20.0)
+    assert t3.stemdiam == pytest.approx(0.30)
+    assert t3.height is None
+
+
+def test_chm_plot_imputation(tmp_path):
+    h_path, d_path = build_chm_files(tmp_path)
+
+    chm = CHMPlot(h_path, sep=',')
+    t = chm.trees[0]
+    assert t.stemdiam is None
+    assert t.height == pytest.approx(15.0)
+    chm_imp = CHMPlot(h_path, sep=',', impute_dbh=True)
+    t_imp = chm_imp.trees[0]
+    expected_diam = t_imp.get_diameter(15.0)
+    assert t_imp.stemdiam == pytest.approx(expected_diam)
+    assert t_imp.height == pytest.approx(15.0)
+
+    chm2 = CHMPlot(d_path, sep=',')
+    t2 = chm2.trees[0]
+    assert t2.stemdiam == pytest.approx(0.30)
+    assert t2.height is None
+    chm2_imp = CHMPlot(d_path, sep=',', impute_h=True)
+    t2_imp = chm2_imp.trees[0]
+    expected_height = t2_imp.get_height(0.30)
+    assert t2_imp.stemdiam == pytest.approx(0.30)
+    assert t2_imp.height == pytest.approx(expected_height)
+
+
+def test_tree_no_auto_impute():
+    t = Tree('t', 0.0, 0.0, stemdiam_cm=30.0)
+    assert t.height is None
+    t2 = Tree('t2', 0.0, 0.0, height_dm=200.0)
+    assert t2.stemdiam is None

--- a/trees.py
+++ b/trees.py
@@ -39,15 +39,9 @@ class Tree:
         self.original_plot = original_plot
         self.species = species
         self.naslund_params = tuple(naslund_params) if naslund_params is not None else None
-        if stemdiam_cm is not None and height_dm is not None:
-            self.stemdiam = stemdiam_cm / 100
-            self.height = height_dm / 10
-        elif stemdiam_cm is None and height_dm is not None:
-            self.stemdiam = self.get_diameter(height_dm / 10)
-            self.height = height_dm / 10
-        elif stemdiam_cm is not None and height_dm is None:
-            self.stemdiam = stemdiam_cm / 100
-            self.height = self.get_height(stemdiam_cm / 100)
+        self.stemdiam = stemdiam_cm / 100 if stemdiam_cm is not None else None
+        self.height = height_dm / 10 if height_dm is not None else None
+        # Do not auto-impute here. Imputation is done explicitly by loaders.
 
     @staticmethod
     def naslund_1936(diameter: float, *params: float) -> float:
@@ -356,6 +350,10 @@ class Stand:
                 height_dm=height_dm,
                 naslund_params=naslund_params,
             )
+            if impute_h and tree.height is None and tree.stemdiam is not None:
+                tree.height = tree.get_height(tree.stemdiam)
+            if impute_dbh and tree.stemdiam is None and tree.height is not None:
+                tree.stemdiam = tree.get_diameter(tree.height)
             # Check if the plot already exists; if not, create it.
             plot = next((p for p in self.plots if p.plotid == plot_id), None)
             if not plot:


### PR DESCRIPTION
## Summary
- Drop stray pass from Tree initializer so metrics are only set when provided
- Add tests covering Stand and CHMPlot to ensure height/DBH are only imputed when explicitly requested

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb14e23083298e1f8207ef09343c