### PR TITLE
Handle missing heights in CHM matching

### DIFF
--- a/tests/test_chm_plot.py
+++ b/tests/test_chm_plot.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from chm_plot import CHMPlot
+from trees import Plot, Tree
 
 
 def test_skip_rows_without_height_or_dbh(tmp_path):
@@ -20,3 +21,21 @@ def test_skip_rows_without_height_or_dbh(tmp_path):
 
     assert len(plot.trees) == 1
     assert plot.trees[0].tree_id == 't1'
+
+
+def test_remove_matches_without_height(tmp_path):
+    chm_df = pd.DataFrame([
+        {'X': 0.5, 'Y': 0.5, 'IDALS': 'c1', 'DBH': 30.0},
+    ])
+    chm_csv = tmp_path / 'chm.csv'
+    chm_df.to_csv(chm_csv, index=False)
+
+    chm_plot = CHMPlot(chm_csv, sep=',')
+
+    field_plot = Plot(1)
+    field_plot.append_tree(Tree('t1', 0.0, 0.0, height_dm=200.0))  # 20 m height
+
+    chm_plot.remove_matches(field_plot)
+
+    assert len(chm_plot.trees) == 0
+    assert len(chm_plot.removed_stems[-1]) == 1


### PR DESCRIPTION
## Summary
- Robustly match CHM trees even when height values are missing by falling back to 2D distance checks
- Add regression test covering CHM matching without height information

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf41568e88329bd9f0226661c2f81