### PR TITLE
Release success dialog grab before closing

### DIFF
--- a/app.py
+++ b/app.py
@@ -827,6 +827,10 @@ class App:
             logging.info("Continue button clicked.")
             try:
                 result["action"] = "continue"
+                try:
+                    dialog.grab_release()
+                except tk.TclError as e:
+                    logging.warning("Error releasing success dialog grab (Continue): %s", e)
                 dialog.destroy()  # Close this dialog first
             except tk.TclError as e:
                 logging.warning(f"Error destroying success dialog (Continue): {e}")
@@ -836,6 +840,10 @@ class App:
             logging.info("Exit button clicked.")
             result["action"] = "exit"
             try:
+                try:
+                    dialog.grab_release()
+                except tk.TclError as e:
+                    logging.warning("Error releasing success dialog grab (Exit): %s", e)
                 dialog.destroy()
             except tk.TclError as e:
                 logging.warning(f"Error destroying success dialog (Exit): {e}")


### PR DESCRIPTION
## Summary
- release the success dialog grab before destroying it so modal state is cleaned up when continuing or exiting

## Testing
- python -m pytest
- python -m flake8 *(fails: flake8 is unavailable in this environment due to proxy restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928689745c08329bcf37f2b5be021ea)